### PR TITLE
add the circuitverse link present in the slides

### DIFF
--- a/Week2.md
+++ b/Week2.md
@@ -12,6 +12,7 @@
 - Online Verilog Simulators:
   - [EDA Playground](https://www.edaplayground.com/)
   - [8 Bit Workshop](https://8bitworkshop.com/)
+  - [CircuitVerse](https://learn.circuitverse.org/)
 - Graphical FPGA Building Tool: [ICE Studio](https://github.com/fpgawars/icestudio)
 
 ## Challenge


### PR DESCRIPTION
I found it in https://docs.google.com/presentation/d/1oOwXZfakxP4jgxQA-depaYAc3wtBubVJPcbfLCDveWg/edit#slide=id.g135efdf6bd6_0_15

Not sure it belongs there. The slides are linked anyway, so it depends on what you planned.

I added it to https://bit.ly/Learn_FPGA so feel free to close this.